### PR TITLE
Change shim from angularjs to angular

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
                     "angular-ckeditor": "angular-ckeditor"
                 },
                 "shim": {
-                    "angular-ckeditor": ["angularjs"]
+                    "angular-ckeditor": ["angular"]
                 }
             }
         </requirejs>


### PR DESCRIPTION
The angularjs webjar exports as "angular", not "angularjs". This commit allows angular-ckeditor to work with the angularjs webjar. Without this commit, when the angularjs-ckeditor webjar is loaded, the browser tries to request angularjs.js (which doesn't exist).
